### PR TITLE
Adapt DeepXTrace to NPU

### DIFF
--- a/src/deepxtrace/diagnose.py
+++ b/src/deepxtrace/diagnose.py
@@ -22,6 +22,7 @@ import time
 import uuid
 import os
 import torch
+# better to add following code after import torch
 try:
     import torch_npu
     from torch_npu.contrib import transfer_to_npu


### PR DESCRIPTION
## Summary by Sourcery
We add some codes to adapt DeepXTrace to NPU, so now it can be used both on GPU and NPU.